### PR TITLE
Corrige mapeo filiation y otros

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/unrn_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/unrn_oai_dc.xsl
@@ -69,13 +69,25 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='date']/doc:element[@name='issued']/doc:element/doc:field[@name='value']">
 				<dc:date><xsl:value-of select="." /></dc:date>
 			</xsl:for-each>
-			<!-- Mapeo provisorio (parche) para dc.descriptor.filation del SNRD -->
-			<!-- FIXME: Eliminar cuando la informaciòn este completa -->
-			<xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='filiation'])">
-				<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
-					<dc:description><xsl:value-of select="concat('Fil: ', ., '. Universidad Nacional de Río Negro; Argentina')" /></dc:description>
-				</xsl:for-each>
-			</xsl:if>
+			<!-- dc.descriptor.filation -->
+			<!-- Pregunta si el campo de filiation existe -->
+			<xsl:choose>
+				<!-- Si no existe, agrego un campo filiation de la UNRN para cada autor -->
+				<xsl:when test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='filiation'])">
+					<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
+						<dc:description><xsl:value-of select="concat('Fil: ', ., '. Universidad Nacional de Río Negro. Río Negro, Argentina')" /></dc:description>
+					</xsl:for-each>
+				</xsl:when>
+				<!-- Si existe, para cada campo filiation pregunto si NO tiene el prefijo Fil -->
+				<xsl:otherwise>
+					<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='filiation']/doc:element/doc:field[@name='value']">
+						<xsl:if test="not(contains(., 'Fil:'))">
+							<!-- Si no lo tiene, lo agrego -->
+							<dc:description><xsl:value-of select="concat('Fil: ', .)" /></dc:description>
+						</xsl:if>
+					</xsl:for-each>
+				</xsl:otherwise>
+			</xsl:choose>
 			<!-- FIN: modificaciones UNRN -->
 
 			<!-- dc.title -->

--- a/dspace/config/crosswalks/oai/metadataFormats/unrn_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/unrn_oai_dc.xsl
@@ -16,12 +16,12 @@
 	<xsl:output omit-xml-declaration="yes" method="xml" indent="yes" />
 	<xsl:template match="/">
 		<oai_dc:dc
-      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" 
+      		xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
 			xmlns:dc="http://purl.org/dc/elements/1.1/" 
 			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 			xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
 		>
-      <!-- INICIO: modificaciones UNRN -->
+			<!-- INICIO: modificaciones UNRN -->
 			<!-- dc.type -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element[@name='openaire']/doc:field[@name='value']">
 				<dc:type><xsl:value-of select="." /></dc:type>
@@ -34,9 +34,9 @@
 				<dc:type><xsl:value-of select="." /></dc:type>
 			</xsl:for-each>
 			<!-- mimetype (format) De esta forma obtenemos el formato directo del archivo -->
-      <xsl:for-each select="doc:metadata/doc:element[@name='bundles']/doc:element[@name='bundle' and doc:field[@name='name' and text()='ORIGINAL']]/doc:element[@name='bitstreams']/doc:element[@name='bitstream']/doc:field[@name='format']">
-        <dc:format><xsl:value-of select="." /></dc:format>
-      </xsl:for-each>
+			<xsl:for-each select="doc:metadata/doc:element[@name='bundles']/doc:element[@name='bundle' and doc:field[@name='name' and text()='ORIGINAL']]/doc:element[@name='bitstreams']/doc:element[@name='bitstream']/doc:field[@name='format']">
+				<dc:format><xsl:value-of select="." /></dc:format>
+			</xsl:for-each>
 			<!--dc.rights.* = rights -->
 			<xsl:variable name="bitstreams" select="doc:metadata/doc:element[@name='bundles']/doc:element[@name='bundle'][./doc:field/text()='ORIGINAL']/doc:element[@name='bitstreams']/doc:element[@name='bitstream']"/>
 			<xsl:variable name="embargoed" select="$bitstreams/doc:field[@name='embargo']"/>
@@ -70,13 +70,13 @@
 				<dc:date><xsl:value-of select="." /></dc:date>
 			</xsl:for-each>
 			<!-- Mapeo provisorio (parche) para dc.descriptor.filation del SNRD -->
-      <!-- FIXME: Eliminar cuando la informaciòn este completa -->
-      <xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='filiation'])">
-        <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
-          <dc:description><xsl:value-of select="concat('Fil: ', ., '. Universidad Nacional de Río Negro; Argentina')" /></dc:description>
-        </xsl:for-each>
-      </xsl:if>
-      <!-- FIN: modificaciones UNRN -->
+			<!-- FIXME: Eliminar cuando la informaciòn este completa -->
+			<xsl:if test="not(doc:metadata/doc:element[@name='dc']/doc:element[@name='description']/doc:element[@name='filiation'])">
+				<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='contributor']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
+					<dc:description><xsl:value-of select="concat('Fil: ', ., '. Universidad Nacional de Río Negro; Argentina')" /></dc:description>
+				</xsl:for-each>
+			</xsl:if>
+			<!-- FIN: modificaciones UNRN -->
 
 			<!-- dc.title -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
@@ -142,7 +142,7 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='relation']/doc:element/doc:element/doc:field[@name='value']">
 				<dc:relation><xsl:value-of select="." /></dc:relation>
 			</xsl:for-each>
-      <!-- dc.coverage -->
+			<!-- dc.coverage -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='coverage']/doc:element/doc:field[@name='value']">
 				<dc:coverage><xsl:value-of select="." /></dc:coverage>
 			</xsl:for-each>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -201,7 +201,6 @@
 
 
      <Filters>
-    
     	<Filter id="snrdFilter">
     		<Definition>
     			<And>
@@ -463,18 +462,15 @@
 					<string>Libro</string>
 					<string>Parte de libro</string>	
 					<string>Objeto de conferencia</string>
-					<string>Acta</string>
-					<string>Resumen</string>
-					<string>Documento de ponencia</string>
-					<string>Presentacion de ponencia</string>
-					<string>Audio de ponencia</string>
-					<string>Video de ponencia</string>
-					<string>Poster de ponencia</string>
-					<string>Patente</string>
 					<string>Documento de trabajo</string>
 					<string>Informe tecnico</string>
 					<string>Datos primarios</string>
-					<string>Otro</string>
+					<string>Proyecto de investigacion</string>
+                    <string>Plano</string>
+                    <string>Mapa</string>
+                    <string>Imagen satelital</string>
+                    <string>Radiografia</string>
+                    <string>Diapositiva de microscopio</string>
 				</list>
 			</Configuration>	
 		</CustomCondition>
@@ -487,11 +483,26 @@
 				<string name="field">dc.type.subtype</string>
 				<string name="operator">equal</string>
 				<list name="values">
+                    <!-- Tesis -->
 					<string>Tesis de grado</string>
                     <string>Tesis de maestria</string>
                     <string>Tesis de doctorado</string>
+                    <!-- Trabajos finales -->
 					<string>Trabajo final de grado</string>
                     <string>Trabajo final de posgrado</string>
+                    <!-- Patente -->
+                    <string>Patente</string>
+                    <string>Marca</string>
+                    <string>Modelo industrial</string>
+                    <string>Modelo de utilidad</string>
+                    <string>Documento legal</string>
+                    <!-- Material artistico -->
+                    <string>Fotografia</string>
+                    <string>Videograbacion</string>
+                    <string>Pelicula documental</string>
+                    <!-- Recension de documento -->
+                    <string>Reseña articulo</string>
+                    <string>Revision literaria</string>
 				</list>
 			</Configuration>	
 		</CustomCondition>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -17,7 +17,6 @@
     <Contexts>
         <!--
             SNRD referencia acerca de los elementos que componen las directrices:
-
             - http://repositoriosdigitales.mincyt.gob.ar/files/Directrices_SNRD_2015.pdf
         -->
 		<Context baseurl="snrd" name="snrd context">
@@ -25,8 +24,7 @@
     		<Filter ref="snrdFilter"/> 
     		<Set ref="snrdSet"/>
     		<Format ref="oaidc"/>
-    		<Format ref="xoai"/> 
-    		
+    		<Format ref="xoai"/>
     		<Description>
     			This context complies with SNRD rules.
     		</Description>
@@ -190,12 +188,21 @@
     <Transformers>
         <Transformer id="driverTransformer">
             <XSLT>transformers/driver.xsl</XSLT>
+            <Description>
+                This transformer complies with Driver Context
+            </Description>
         </Transformer>
         <Transformer id="openaireTransformer">
             <XSLT>transformers/openaire.xsl</XSLT>
+            <Description>
+                This transformer complies with OpenAIRE Context
+            </Description>
         </Transformer>
         <Transformer id="snrdTransformer">
             <XSLT>transformers/snrd.xsl</XSLT>
+            <Description>
+                This transformer complies with SNRD Context
+            </Description>
         </Transformer>
     </Transformers>
 

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -173,11 +173,10 @@
 					<label>Filiación de los Autores</label>
 					<input-type>onebox</input-type>
 					<hint>
-						Registrar la filiación institucional de cada uno de los autores del documento utilizando
-						ocurrencias separadas (Si el autor posee mas de una filiación, colocarlo en otra ocurrencia).
-						Utilizar el prefijo "Fil:" seguido del apellido y nombre completo, la institución
-						en forma de jerarquía, la provincia y el país de origen. Ejemplo: Fil: Garcia, Juan Pablo. Universidad
-						Nacional de Río Negro. Laboratorio de Informática Aplicada. Río Negro, Argentina.
+						Registrar, por autor, cada filiación institucional ocurrencias separadas.
+						Indicar el apellido y nombre completo, la institución en forma de jerarquía, la provincia y el
+						país de origen. Ejemplo: Garcia, Juan Pablo. Universidad Nacional de Río Negro. Laboratorio de
+						Informática Aplicada. Río Negro, Argentina.
 					</hint>
 					<required>Debe ingresar las filaciones correspondientes</required>
 				</field>


### PR DESCRIPTION
Closes #112 

- Elimina el prefijo `Fil: ` del input-forms.xml
- Corrige los mapeos del campo dc.description.filiation a fin de cumplir con lo siguiente:
    - Registros que no cuentan con dicho campo: se crea un campo filiacion para cada autor del registro
    - Registros que cuentan con el campo filiation y tienen el prefijo `Fil: `: no se modifica en absoluto
    - Registros que cuentan con el campo filiation y no tienen el prefijo `Fil: `: le agrega dicho prefijo
- Modifica la estructura del archivo `default.license` para una mejor lectura a la hora de aceptar la licencia del RID en autoarchivo
- Modifica los tipos y subtipos que se admiten en el setSNRD, ya que habia tipos que no se utilizaban mas y otros que faltaban agregar.
